### PR TITLE
Reduce output file sizes in single-cell pipelines

### DIFF
--- a/R/minimap2_align.R
+++ b/R/minimap2_align.R
@@ -65,7 +65,11 @@ minimap2_align <- function(config, fa_file, fq_in, annot, outdir, minimap2 = NA,
     samtools <- find_bin("samtools")
   }
 
-  has_tags <- grepl("\t", readLines(fq_in, n = 1))
+  if (endsWith(fq_in, ".gz")) {
+    has_tags <- grepl("\t", readLines(gzfile(fq_in), n = 1))
+  } else {
+    has_tags <- grepl("\t", readLines(fq_in, n = 1))
+  }
   tags <- switch(has_tags, "-y")
 
   minimap2_args <- c("-ax", "splice", tags, "-t", threads, "-k14", "--secondary=no",
@@ -177,7 +181,11 @@ minimap2_realign <- function(config, fq_in, outdir, minimap2, samtools = NULL, p
   }
 
   if (missing("minimap2_args") || !is.character(minimap2_args)) {
-    has_tags <- grepl("\t", readLines(fq_in, n = 1))
+    if (endsWith(fq_in, ".gz")) {
+      has_tags <- grepl("\t", readLines(gzfile(fq_in), n = 1))
+    } else {
+      has_tags <- grepl("\t", readLines(fq_in, n = 1))
+    }
     tags <- switch(has_tags, "-y")
     minimap2_args <- c("-ax", "map-ont", tags, "-p", "0.9", "--end-bonus", "10", "-N",
       "3", "-t", threads, "--seed", config$pipeline_parameters$seed)

--- a/R/sc_long_multisample_pipeline.R
+++ b/R/sc_long_multisample_pipeline.R
@@ -157,7 +157,7 @@ sc_long_multisample_pipeline <- function(annotation, fastqs, outdir, genome_fa,
   # check input length of input fastqs, barcodes_file
   if (config$pipeline_parameters$do_barcode_demultiplex && is.null(barcodes_file)) {
     # check if the output exist
-    infqs <- file.path(outdir, paste(names(fastqs), "matched_reads.fastq", sep = "_"))
+    infqs <- file.path(outdir, paste(names(fastqs), "matched_reads.fastq.gz", sep = "_"))
     if (any(file.exists(infqs))) {
       stop(paste0(
         "Error: Found existing demultiplexed fastq files in the output directory.",
@@ -178,14 +178,14 @@ sc_long_multisample_pipeline <- function(annotation, fastqs, outdir, genome_fa,
     for (i in 1:length(fastqs)) {
       blaze(expect_cell_numbers[i], fastqs[i],
         "output-prefix" = file.path(outdir, paste0(names(fastqs)[i], "_")),
-        "output-fastq" = "matched_reads.fastq",
+        "output-fastq" = "matched_reads.fastq.gz",
         "threads" = config$pipeline_parameters$threads,
         "max-edit-distance" = config$barcode_parameters$max_bc_editdistance,
         "overwrite" = TRUE
       )
     }
   } else if (config$pipeline_parameters$do_barcode_demultiplex && length(barcodes_file) >= 1) {
-    infqs <- file.path(outdir, paste(names(fastqs), "matched_reads.fastq", sep = "_"))
+    infqs <- file.path(outdir, paste(names(fastqs), "matched_reads.fastq.gz", sep = "_"))
     if (any(file.exists(infqs))) {
       stop(paste0(
         "Error: Found existing demultiplexed fastq files in the output directory.",
@@ -204,11 +204,11 @@ sc_long_multisample_pipeline <- function(annotation, fastqs, outdir, genome_fa,
       stop(length(barcodes_file), " barcode allow-lists provided while there are ", length(fastqs),
         "fastq file. Please either provide one allow-list per sample, or one allow-list for all samples.")
     }
-    infqs <- file.path(outdir, paste(names(fastqs), "matched_reads.fastq", sep = "_"))
     bc_stats <- file.path(outdir, paste(names(fastqs), "matched_barcode_stat", sep = "_"))
+    infqs_uncompressed <- gsub("\\.gz$", "", infqs)
     metadata$results[["find_barcode"]] <-
       find_barcode(fastq = fastqs, barcodes_file = barcodes_file, stats_out = bc_stats,
-        reads_out = infqs,
+        reads_out = infqs_uncompressed,
         pattern = setNames(
           as.character(config$barcode_parameters$pattern),
           names(config$barcode_parameters$pattern)
@@ -222,6 +222,10 @@ sc_long_multisample_pipeline <- function(annotation, fastqs, outdir, genome_fa,
         strand = config$barcode_parameters$strand,
         threads = config$pipeline_parameters$threads
       )
+
+    for (i in 1:length(infqs_uncompressed)) {
+      gzip(filename = infqs_uncompressed[i], destname = infqs[i])
+    }
   } else {
     infqs <- fastqs
   } # requesting to not match barcodes implies `fastq` has already been run through the
@@ -312,7 +316,7 @@ if (config$pipeline_parameters$do_read_realignment) {
   # Set file paths for realignment
   if (config$pipeline_parameters$do_gene_quantification) {
     cat("#### Realigning deduplicated reads to transcript using minimap2\n")
-    infqs_realign <- file.path(outdir, paste(names(fastqs), "matched_reads_dedup.fastq", sep = "_"))
+    infqs_realign <- file.path(outdir, paste(names(fastqs), "matched_reads_dedup.fastq.gz", sep = "_"))
   } else {
     infqs_realign <- fastqs # if no gene quantification, use the original fastqs
   }

--- a/R/sc_long_pipeline.R
+++ b/R/sc_long_pipeline.R
@@ -144,9 +144,9 @@ sc_long_pipeline <- function(
 
   infq <- NULL
   if (config$pipeline_parameters$do_barcode_demultiplex) {
-    if (file.exists(file.path(outdir, "matched_reads.fastq"))) {
+    if (file.exists(file.path(outdir, "matched_reads.fastq.gz"))) {
       stop(paste0(
-        "The demultiplexing output file matched_reads.fastq already exists in the output directory.",
+        "The demultiplexing output file matched_reads.fastq.gz already exists in the output directory.",
         " If you want to run the demultiplexing step again, please remove the file first,  ",
         "otherwise please set `do_barcode_demultiplex = false` in the JSON configuration file."
       ))
@@ -160,13 +160,13 @@ sc_long_pipeline <- function(
       }
       blaze(expect_cell_number, fastq,
         "output-prefix" = paste0(outdir, "/"),
-        "output-fastq" = "matched_reads.fastq",
+        "output-fastq" = "matched_reads.fastq.gz",
         "threads" = config$pipeline_parameters$threads,
         "max-edit-distance" = config$barcode_parameters$max_bc_editdistance,
         "overwrite" = TRUE
       )
 
-      infq <- file.path(outdir, "matched_reads.fastq")
+      infq <- file.path(outdir, "matched_reads.fastq.gz")
     } else {
       # run flexiplex
       cat(format(Sys.time(), "%X %a %b %d %Y"), "Demultiplexing using flexiplex...\n")
@@ -177,14 +177,14 @@ sc_long_pipeline <- function(
         )
       }
       cat("Matching cell barcodes...\n")
-      infq <- file.path(outdir, "matched_reads.fastq")
+      infq_uncompressed <- file.path(outdir, "matched_reads.fastq")
       bc_stat <- file.path(outdir, "matched_barcode_stat")
       metadata$results <- c(metadata$results,
         list("find_barcode" = find_barcode(
           fastq = fastq,
           barcodes_file = barcodes_file,
           stats_out = bc_stat,
-          reads_out = infq,
+          reads_out = infq_uncompressed,
           pattern = setNames(
             as.character(config$barcode_parameters$pattern),
             names(config$barcode_parameters$pattern)
@@ -200,6 +200,8 @@ sc_long_pipeline <- function(
         )
         )
       )
+      infq <- file.path(outdir, "matched_reads.fastq.gz")
+      gzip(filename = infq_uncompressed, destname = infq)
     }
     cat(format(Sys.time(), "%X %a %b %d %Y"), "Demultiplex done\n")
   } else {
@@ -290,7 +292,7 @@ sc_long_pipeline <- function(
   if (config$pipeline_parameters$do_read_realignment) {
     cat("#### Realigning deduplicated reads to transcript using minimap2\n")
     if (config$pipeline_parameters$do_gene_quantification) {
-      infq_realign <- file.path(outdir, "matched_reads_dedup.fastq")
+      infq_realign <- file.path(outdir, "matched_reads_dedup.fastq.gz")
     } else {
       infq_realign <- infq
     }

--- a/inst/python/count_gene.py
+++ b/inst/python/count_gene.py
@@ -774,11 +774,11 @@ def quantification(annotation, outdir, pipeline,
                   infq=None,  sample_names=None, random_seed=2024, **kwargs):
     if pipeline == "sc_single_sample":
         if not infq:
-            infq = os.path.join(outdir, "matched_reads.fastq")
+            infq = os.path.join(outdir, "matched_reads.fastq.gz")
         in_bam = os.path.join(outdir, "align2genome.bam")
         out_csv = os.path.join(outdir, "gene_count.csv")
         out_fig = os.path.join(outdir, "saturation_curve.png") if saturation_curve else None
-        out_fastq = os.path.join(outdir, "matched_reads_dedup.fastq")
+        out_fastq = os.path.join(outdir, "matched_reads_dedup.fastq.gz")
 
         dedup_read_lst, umi_lst = \
                         quantify_gene(in_bam, annotation, n_process, 
@@ -807,8 +807,8 @@ def quantification(annotation, outdir, pipeline,
         for idx, sample in enumerate(sample_names):
             sample_bam = os.path.join(outdir, sample + "_align2genome.bam")
             sys.stderr.write("parsing " + sample_bam + "...\n")
-            in_fastq = infq[idx] if infq is not None else os.path.join(outdir,sample+ "_"+ "matched_reads.fastq")
-            out_fastq = os.path.join(outdir,sample+ "_"+ "matched_reads_dedup.fastq")
+            in_fastq = infq[idx] if infq is not None else os.path.join(outdir,sample+ "_"+ "matched_reads.fastq.gz")
+            out_fastq = os.path.join(outdir,sample+ "_"+ "matched_reads_dedup.fastq.gz")
             out_csv = os.path.join(outdir, sample+ "_"+"gene_count.csv")
             out_fig = os.path.join(outdir, sample+ "_"+"saturation_curve.png") if saturation_curve else None
             #out_read_lst = os.path.join(outdir, sample+ "_"+"deduplicated_read_id.txt")


### PR DESCRIPTION
Output gzipped FASTQ files in `sc_long_pipeline()` and `sc_long_multisample_pipeline()` instead of uncompressed files to lower disk space usage. This PR also includes changes to `minimap2_align()` and `minimap2_realign()` that allow them to read gzipped FASTQ input files.