### PR TITLE
Fix the expect_cell_number check in the single-cell multi-sample pipeline

### DIFF
--- a/R/methods-MultiSampleSCPipeline.R
+++ b/R/methods-MultiSampleSCPipeline.R
@@ -144,7 +144,7 @@ MultiSampleSCPipeline <- function(
 
   if (steps["barcode_demultiplex"] &&
     config$pipeline_parameters$demultiplexer == "BLAZE" &&
-    is.na(pipeline@expect_cell_number)) {
+    any(is.na(pipeline@expect_cell_number))) {
     stop("demultiplexer set to 'BLAZE', which requires 'expect_cell_number' to be provided.")
   }
 


### PR DESCRIPTION
In `MultiSampleSCPipeline`, `pipeline@expect_cell_number` might be a vector of expected cell counts. Since `is.na()` is a vectorized function in R, wrap it in `any()` to prevent a data coercion error.